### PR TITLE
Authentication

### DIFF
--- a/app/account_manager.py
+++ b/app/account_manager.py
@@ -4,10 +4,14 @@ from beanie import PydanticObjectId, Document
 from fastapi import Depends, Request
 from fastapi_users import BaseUserManager, FastAPIUsers
 from fastapi_users.authentication import (AuthenticationBackend,
-                                          BearerTransport, CookieTransport)
+                                        #   BearerTransport, 
+                                          CookieTransport)
+from app.utils.auth_transport import BearerTransport
 from fastapi_users.db import BeanieUserDatabase, ObjectIDIDMixin
-from fastapi_users_db_beanie.access_token import BeanieAccessTokenDatabase, BeanieBaseAccessToken
-from fastapi_users.authentication.strategy.db import AccessTokenDatabase, DatabaseStrategy
+# from fastapi_users_db_beanie.access_token import BeanieAccessTokenDatabase, BeanieBaseAccessToken
+from app.utils.token_db import BeanieAccessTokenDatabase, BeanieBaseAccessToken
+# from fastapi_users.authentication.strategy.db import AccessTokenDatabase, DatabaseStrategy
+from app.utils.auth_strategy import AccessTokenDatabase, DatabaseStrategy
 from app.models.documents import Account
 from app.utils import colored_dbg
 

--- a/app/actions/authentication.py
+++ b/app/actions/authentication.py
@@ -1,0 +1,44 @@
+import re
+from app.models.documents import Account
+from app.exceptions import authentication as AuthExceptions
+from app.exceptions import account as AccountExceptions
+from app.utils import colored_dbg as Debug
+from app.account_manager import jwt_backend
+
+
+async def refresh_token(authorization, refresh_token, token_db, strategy):
+    # Make sure the Authorization header is valid and extract the access token
+    try:
+        access_token = re.match(r'^Bearer ([A-z0-9\-]+)$', authorization).group(1)  # type: ignore
+    except Exception as e:
+        Debug.print_error(str(e))
+        raise AuthExceptions.InvalidAuthorizationHeader()
+
+    # Get the token data from the database using the access token
+    # NOTE: We do not supply a max_age parameter in case access tokens has already expired
+    token_data = await token_db.get_by_token(access_token)
+
+    # Make sure the access token exists in the database
+    if token_data is None:
+        raise AuthExceptions.InvalidAccessToken()
+
+    # Make sure the access token is associated with the supplied refresh token
+    if token_data.refresh_token != refresh_token:
+        raise AuthExceptions.InvalidRefreshToken()
+
+    # Get the user from the database using the user ID in the token data
+    user = await Account.get(token_data.user_id)
+    if user is None:
+        raise AccountExceptions.AccountNotFound(token_data.user_id)
+
+    # Check if the refresh token is the most recent one
+    all_tokens = await token_db.get_token_family_by_user_id(user.id)
+    if (await all_tokens.to_list())[0].refresh_token != refresh_token:
+        # If not, delete all tokens associated with the user and return an error
+        await strategy.destroy_token_family(user)
+        raise AuthExceptions.refreshTokenExpired()
+
+    # Login the user using the supplied strategy
+    # Generate new pair of access and refresh tokens
+    # Returns Response object with LoginOutput schema
+    return await jwt_backend.login(strategy, user)

--- a/app/app.py
+++ b/app/app.py
@@ -6,21 +6,24 @@ from app.mongo_db import mainDB, DOCUMENT_MODELS
 from app.routes import workspace as WorkspaceRoutes
 from app.routes import group as GroupRoutes
 from app.routes import account as AccountRoutes
+from app.routes import websocket as WebSocketRoutes
+from app.routes import authentication as AuthenticationRoutes
 from app.config import get_settings
-from app.schemas.account import Account, CreateAccount, UpdateAccount
-from app.account_manager import auth_backend, fastapi_users
 from app.dependencies import set_active_user
 
 
+# Apply setting from configuration file
 settings = get_settings()
 
+# Create FastAPI application
 app = FastAPI(
-    title=settings.app_name,
-    description="A REST API to manage users and polls",
-    version=settings.app_version,
+    title=settings.app_name,               # Title of the application
+    description=settings.app_description,  # Description of the application
+    version=settings.app_version,          # Version of the application
 )
 
 
+# Add endpoints defined in the routes directory
 app.include_router(WorkspaceRoutes.open_router,
                    prefix="/workspaces",
                    tags=["Workspaces"],
@@ -33,27 +36,19 @@ app.include_router(GroupRoutes.router,
                    prefix="/groups",
                    tags=["Groups"],
                    dependencies=[Depends(set_active_user)])
+app.include_router(WebSocketRoutes.router,
+                   prefix="/ws",
+                   tags=["WebSocket"])
 app.include_router(AccountRoutes.router,
                    prefix="/accounts",
                    tags=["Accounts"],
                    dependencies=[Depends(set_active_user)])
-app.include_router(fastapi_users.get_auth_router(auth_backend),
-                   prefix="/auth/jwt",
+app.include_router(AuthenticationRoutes.router,
+                   prefix="/auth",
                    tags=["Authentication"])
-app.include_router(fastapi_users.get_register_router(Account, CreateAccount),
-                   prefix="/auth",
-                   tags=["Auth"])
-app.include_router(fastapi_users.get_reset_password_router(),
-                   prefix="/auth",
-                   tags=["Auth"])
-app.include_router(fastapi_users.get_verify_router(Account),
-                   prefix="/auth",
-                   tags=["Auth"])
-app.include_router(fastapi_users.get_users_router(Account, UpdateAccount),
-                   prefix="/accounts",
-                   tags=["Accounts"])
 
 
+# Add CORS middleware to allow cross-origin requests
 origins = ["*"]
 
 app.add_middleware(
@@ -65,6 +60,7 @@ app.add_middleware(
 )
 
 
+# Initialize Mongo Database on startup
 @app.on_event("startup")
 async def on_startup() -> None:
     # Simplify operation IDs so that generated API clients have simpler function names

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,4 +1,5 @@
-from fastapi import Depends, Request, HTTPException
+from typing import Annotated
+from fastapi import Cookie, Depends, Query, Request, HTTPException, WebSocket
 from app.account_manager import current_active_user, get_current_active_user
 from app.models.documents import ResourceID, Workspace, Group, Account
 from app.utils import permissions as Permissions
@@ -18,6 +19,14 @@ async def get_account(account_id: ResourceID) -> Account:
     if not account:
         raise AccountExceptions.AccountNotFound(account_id)
     return account
+
+
+async def websocket_auth(
+    websocket: WebSocket,
+    session: Annotated[str | None, Cookie()] = None,
+    token: Annotated[str | None, Query()] = None,
+):
+    return {"cookie": session, "token": token}
 
 
 # Dependency for getting a workspace with the given id

--- a/app/exceptions/authentication.py
+++ b/app/exceptions/authentication.py
@@ -1,0 +1,27 @@
+from fastapi import status
+from app.exceptions import resource
+# from app.models.documents import ResourceID
+
+
+class InvalidAuthorizationHeader(resource.APIException):
+    def __init__(self):
+        super().__init__(code=status.HTTP_400_BAD_REQUEST,
+                         detail="Invalid Authorization header")
+
+
+class InvalidAccessToken(resource.APIException):
+    def __init__(self):
+        super().__init__(code=status.HTTP_401_UNAUTHORIZED,
+                         detail="Invalid Access token")
+
+
+class InvalidRefreshToken(resource.APIException):
+    def __init__(self):
+        super().__init__(code=status.HTTP_401_UNAUTHORIZED,
+                         detail="Invalid Refresh token")
+
+
+class refreshTokenExpired(resource.APIException):
+    def __init__(self):
+        super().__init__(code=status.HTTP_401_UNAUTHORIZED,
+                         detail="Refresh token expired; Please login again")

--- a/app/routes/account.py
+++ b/app/routes/account.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter, status, HTTPException, Depends
+from app.account_manager import fastapi_users
 from app.actions import account as AccountActions
 from app.exceptions.resource import APIException
 from app.models.documents import Account
 from app.dependencies import get_account
+from app.schemas import account as AccountSchemas
 
 
 # APIRouter creates path operations for user module
@@ -53,3 +55,9 @@ async def delete_user(account: Account = Depends(get_account)):
         await AccountActions.delete_account(account)
     except APIException as e:
         raise HTTPException(status_code=e.code, detail=str(e))
+
+
+# Update current user account
+router.include_router(fastapi_users.get_users_router(AccountSchemas.Account, AccountSchemas.UpdateAccount),
+                      prefix="/accounts",
+                      tags=["Accounts"])

--- a/app/routes/authentication.py
+++ b/app/routes/authentication.py
@@ -1,0 +1,78 @@
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi.security import OAuth2PasswordRequestForm
+from fastapi_users import BaseUserManager, models
+from fastapi_users.openapi import OpenAPIResponseType
+from fastapi_users.router.common import ErrorCode, ErrorModel
+from fastapi_users.authentication import Strategy
+
+from app.account_manager import fastapi_users, get_current_active_user, get_user_manager
+from app.account_manager import jwt_backend, get_database_strategy, get_access_token_db
+from app.schemas.account import Account, CreateAccount
+from app.schemas import authentication as AuthSchemas
+
+router = APIRouter()
+
+
+router.include_router(fastapi_users.get_register_router(Account, CreateAccount))
+router.include_router(fastapi_users.get_reset_password_router())
+router.include_router(fastapi_users.get_verify_router(Account))
+# router.include_router(fastapi_users.get_auth_router(jwt_backend), prefix="/jwt")
+
+
+@router.post("/jwt/refresh")
+async def refresh_jwt(response: Response,
+                      token_db=Depends(get_access_token_db),
+                      user=Depends(get_current_active_user)):
+
+    res = await jwt_backend.login(strategy=get_database_strategy(token_db), user=user)
+    return res
+
+
+login_responses: OpenAPIResponseType = {
+    status.HTTP_400_BAD_REQUEST: {
+        "model": ErrorModel,
+        "content": {
+            "application/json": {
+                "examples": {
+                    ErrorCode.LOGIN_BAD_CREDENTIALS: {
+                        "summary": "Bad credentials or the user is inactive.",
+                        "value": {"detail": ErrorCode.LOGIN_BAD_CREDENTIALS},
+                    },
+                    ErrorCode.LOGIN_USER_NOT_VERIFIED: {
+                        "summary": "The user is not verified.",
+                        "value": {"detail": ErrorCode.LOGIN_USER_NOT_VERIFIED},
+                    },
+                }
+            }
+        },
+    },
+    **jwt_backend.transport.get_openapi_login_responses_success(),
+}
+
+
+@router.post(
+    "/jwt/login",
+    name=f"auth:{jwt_backend.name}.login",
+    responses=login_responses,
+)
+async def login(
+    request: Request,
+    credentials: OAuth2PasswordRequestForm = Depends(),
+    user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
+    strategy: Strategy[models.UP, models.ID] = Depends(jwt_backend.get_strategy),
+):
+    user = await user_manager.authenticate(credentials)
+
+    if user is None or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ErrorCode.LOGIN_BAD_CREDENTIALS,
+        )
+    # if requires_verification and not user.is_verified:
+    #     raise HTTPException(
+    #         status_code=status.HTTP_400_BAD_REQUEST,
+    #         detail=ErrorCode.LOGIN_USER_NOT_VERIFIED,
+    #     )
+    token = await strategy.write_token(user)
+
+    return AuthSchemas.LoginOutput(access_token=token, refresh_token=token)

--- a/app/routes/authentication.py
+++ b/app/routes/authentication.py
@@ -1,31 +1,73 @@
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from typing import Annotated
+from fastapi import APIRouter, Depends, HTTPException, Header, Request, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi_users import BaseUserManager, models
 from fastapi_users.openapi import OpenAPIResponseType
 from fastapi_users.router.common import ErrorCode, ErrorModel
 from fastapi_users.authentication import Strategy
 
-from app.account_manager import fastapi_users, get_current_active_user, get_user_manager
+from app.account_manager import fastapi_users, get_user_manager
 from app.account_manager import jwt_backend, get_database_strategy, get_access_token_db
-from app.schemas.account import Account, CreateAccount
-from app.schemas import authentication as AuthSchemas
+from app.schemas import account as AccountSchemas
+# from app.schemas import authentication as AuthSchemas
+from app.models.documents import Account
+from app.utils.token_db import BeanieAccessTokenDatabase
+from app.utils.auth_strategy import DatabaseStrategy
+
+
+import re
 
 router = APIRouter()
 
 
-router.include_router(fastapi_users.get_register_router(Account, CreateAccount))
+router.include_router(fastapi_users.get_register_router(AccountSchemas.Account, AccountSchemas.CreateAccount))
+# TODO: Invalidate all tokens associated with the user when they delete their account or reset their passwords
 router.include_router(fastapi_users.get_reset_password_router())
-router.include_router(fastapi_users.get_verify_router(Account))
+router.include_router(fastapi_users.get_verify_router(AccountSchemas.Account))
+
+# The Auth router is not included because we will be using our own custom auth router
 # router.include_router(fastapi_users.get_auth_router(jwt_backend), prefix="/jwt")
 
 
 @router.post("/jwt/refresh")
 async def refresh_jwt(response: Response,
-                      token_db=Depends(get_access_token_db),
-                      user=Depends(get_current_active_user)):
+                      authorization: Annotated[str | None, Header()] = None,
+                      refresh_token: Annotated[str | None, Header()] = None,
+                      token_db: BeanieAccessTokenDatabase = Depends(get_access_token_db),
+                      strategy: DatabaseStrategy = Depends(get_database_strategy)):
+    # Make sure the Authorization header is valid and extract the access token
+    try:
+        access_token = re.match(r'^Bearer ([A-z0-9\-]+)$', authorization).group(1)  # type: ignore
+    except Exception as e:
+        print(e)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid Authorization header")
 
-    res = await jwt_backend.login(strategy=get_database_strategy(token_db), user=user)
-    return res
+    # Get the token data from the database using the access token
+    # NOTE: We do not supply a max_age parameter in case access tokens has already expired
+    token_data = await token_db.get_by_token(access_token)
+
+    # Make sure the access token exists in the database
+    if token_data is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid access token")
+
+    # Make sure the access token is associated with the supplied refresh token
+    if token_data.refresh_token != refresh_token:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid refresh token")
+
+    # Get the user from the database using the user ID in the token data
+    user = await Account.get(token_data.user_id)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="User not found")
+
+    # Check if the refresh token is the most recent one
+    all_tokens = await token_db.get_token_family_by_user_id(user.id)
+    if (await all_tokens.to_list())[0].refresh_token != refresh_token:
+        # If not, delete all tokens associated with the user and return an error
+        await strategy.destroy_token_family(user)
+        return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid refresh token")
+
+    # Generate new pair of access and refresh tokens
+    return await jwt_backend.login(strategy, user)
 
 
 login_responses: OpenAPIResponseType = {
@@ -73,6 +115,5 @@ async def login(
     #         status_code=status.HTTP_400_BAD_REQUEST,
     #         detail=ErrorCode.LOGIN_USER_NOT_VERIFIED,
     #     )
-    token = await strategy.write_token(user)
 
-    return AuthSchemas.LoginOutput(access_token=token, refresh_token=token)
+    return await jwt_backend.login(strategy, user)

--- a/app/routes/websocket.py
+++ b/app/routes/websocket.py
@@ -1,0 +1,32 @@
+# Handle WebSocket connections
+from typing import Annotated
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
+from app.models.documents import Account
+from app.websocket_manager import WebSocketManager
+from app.dependencies import websocket_auth
+from app.account_manager import AccessToken
+
+
+router = APIRouter()
+
+# Create a connection manager to manage WebSocket connections
+manager = WebSocketManager()
+
+
+@router.websocket("")
+async def open_websocket_endpoint(websocket: WebSocket, auth: Annotated[str, Depends(websocket_auth)]):
+    await manager.connect(websocket)
+    print("auth: ", auth)
+    if auth["cookie"]:
+        print("cookie: ", auth.cookie)
+        # account_id = AccessToken.find(user_id=auth.token)
+    elif auth["token"]:
+        print("token: ", auth.token)
+    else:
+        print("no auth")
+    try:
+        while True:
+            data = await websocket.receive_text()
+            await manager.send_personal_message(f"You wrote: {data}", websocket)
+    except WebSocketDisconnect:
+        manager.disconnect(websocket)

--- a/app/schemas/authentication.py
+++ b/app/schemas/authentication.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class LoginOutput(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+    expires: int = 3600

--- a/app/utils/auth_strategy.py
+++ b/app/utils/auth_strategy.py
@@ -1,0 +1,66 @@
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Generic, Optional
+
+from fastapi_users import exceptions, models
+from fastapi_users.authentication.strategy.base import Strategy
+from fastapi_users.authentication.strategy.db.adapter import AccessTokenDatabase
+from fastapi_users.authentication.strategy.db.models import AP
+from fastapi_users.manager import BaseUserManager
+
+
+class DatabaseStrategy(
+    Strategy[models.UP, models.ID], Generic[models.UP, models.ID, AP]
+):
+    def __init__(
+        self, database: AccessTokenDatabase[AP], lifetime_seconds: Optional[int] = None
+    ):
+        self.database = database
+        self.lifetime_seconds = lifetime_seconds
+
+    async def read_token(
+        self, token: Optional[str], user_manager: BaseUserManager[models.UP, models.ID]
+    ) -> Optional[models.UP]:
+        if token is None:
+            return None
+
+        max_age = None
+        if self.lifetime_seconds:
+            max_age = datetime.now(timezone.utc) - timedelta(
+                seconds=self.lifetime_seconds
+            )
+            print("max_age", max_age)
+
+        access_token = await self.database.get_by_token(token, max_age)
+        if access_token is None:
+            return None
+
+        try:
+            parsed_id = user_manager.parse_id(access_token.user_id)
+            return await user_manager.get(parsed_id)
+        except (exceptions.UserNotExists, exceptions.InvalidID):
+            return None
+
+    async def write_token(self, user: models.UP) -> str:
+        token_dict = self._create_access_token_dict(user)
+        token = await self.database.create(token_dict)
+        return token
+
+    async def destroy_token(self, token: str, user: models.UP) -> None:
+        access_token = await self.database.get_by_token(token)
+        if access_token is not None:
+            await self.database.delete(access_token)
+
+    # Destroy all tokens for a user
+    async def destroy_token_family(self, user: models.UP) -> None:
+        tokens = await self.database.get_token_family_by_user_id(user.id)
+        await tokens.delete()
+
+    def _create_access_token_dict(self, user: models.UP) -> Dict[str, Any]:
+        access_token = secrets.token_urlsafe()
+        refresh_token = secrets.token_urlsafe()
+        return {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "user_id": user.id
+        }

--- a/app/utils/auth_transport.py
+++ b/app/utils/auth_transport.py
@@ -1,0 +1,64 @@
+from fastapi import Response, status
+from fastapi.responses import JSONResponse
+from fastapi.security import OAuth2PasswordBearer
+from pydantic import BaseModel
+
+from fastapi_users.authentication.transport.base import (
+    Transport,
+    TransportLogoutNotSupportedError,
+)
+from fastapi_users.openapi import OpenAPIResponseType
+
+
+class BearerResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str
+    expires: int
+
+
+class BearerTransport(Transport):
+    scheme: OAuth2PasswordBearer
+
+    def __init__(self, tokenUrl: str):
+        self.scheme = OAuth2PasswordBearer(tokenUrl, auto_error=False)
+
+    async def get_login_response(self, token: str) -> Response:
+        bearer_response = BearerResponse(access_token=token.access_token,
+                                         refresh_token=token.refresh_token,
+                                         token_type="bearer",
+                                         expires=3600)
+        return JSONResponse(bearer_response.dict())
+
+    async def get_logout_response(self) -> Response:
+        raise TransportLogoutNotSupportedError()
+
+    @staticmethod
+    def get_openapi_login_responses_success() -> OpenAPIResponseType:
+        return {
+            status.HTTP_200_OK: {
+                "model": BearerResponse,
+                "content": {
+                    "application/json": {
+                        "example": {
+                            "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1"
+                            "c2VyX2lkIjoiOTIyMWZmYzktNjQwZi00MzcyLTg2Z"
+                            "DMtY2U2NDJjYmE1NjAzIiwiYXVkIjoiZmFzdGFwaS"
+                            "11c2VyczphdXRoIiwiZXhwIjoxNTcxNTA0MTkzfQ."
+                            "M10bjOe45I5Ncu_uXvOmVV8QxnL-nZfcH96U90JaocI",
+                            "refresh_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1"
+                            "c2VyX2lkIjoiOTIyMWZmYzktNjQwZi00MzcyLTg2Z"
+                            "DMtY2U2NDJjYmE1NjAzIiwiYXVkIjoiZmFzdGFwaS"
+                            "11c2VyczphdXRoIiwiZXhwIjoxNTcxNTA0MTkzfQ."
+                            "M10bjOe45I5Ncu_uXvOmVV8QxnL-nZfcH96U90JaocI",
+                            "token_type": "bearer",
+                            "expires": 3600,
+                        }
+                    }
+                },
+            },
+        }
+
+    @staticmethod
+    def get_openapi_logout_responses_success() -> OpenAPIResponseType:
+        return {}

--- a/app/utils/token_db.py
+++ b/app/utils/token_db.py
@@ -1,0 +1,73 @@
+from datetime import datetime, timezone
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    Optional,
+    Type,
+    TypeVar,
+)
+
+from beanie import Document, PydanticObjectId
+from fastapi_users.authentication.strategy.db import AccessTokenDatabase
+from pydantic import BaseModel, Field
+from pymongo import IndexModel
+
+
+class BeanieBaseAccessToken(BaseModel):
+    access_token: str
+    refresh_token: str
+    user_id: PydanticObjectId
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    class Settings:
+        indexes = [IndexModel("access_token", unique=True),
+                   IndexModel("refresh_token", unique=True)]
+
+
+class BeanieBaseAccessTokenDocument(BeanieBaseAccessToken, Document):  # type: ignore
+    pass
+
+
+AP_BEANIE = TypeVar("AP_BEANIE", bound=BeanieBaseAccessTokenDocument)
+
+
+class BeanieAccessTokenDatabase(Generic[AP_BEANIE], AccessTokenDatabase[AP_BEANIE]):
+    """
+    Access token database adapter for Beanie.
+
+    :param access_token_model: Beanie access token model.
+    """
+
+    def __init__(self, access_token_model: Type[AP_BEANIE]):
+        self.access_token_model = access_token_model
+
+    async def get_by_token(
+        self, token: str, max_age: Optional[datetime] = None
+    ) -> Optional[AP_BEANIE]:
+        query: Dict[str, Any] = {"access_token": token}
+        if max_age is not None:
+            query["created_at"] = {"$gte": max_age}
+        res = await self.access_token_model.find_one(query)
+        return res
+
+    # Returns find query (not a document)
+    async def get_token_family_by_user_id(self, user_id: PydanticObjectId):
+        access_token = self.access_token_model.find({"user_id": user_id}, sort=[("created_at", -1)])
+        return access_token
+
+    async def create(self, create_dict: Dict[str, Any]) -> AP_BEANIE:
+        access_token = self.access_token_model(**create_dict)
+        await access_token.create()
+        return access_token
+
+    async def update(
+        self, access_token: AP_BEANIE, update_dict: Dict[str, Any]
+    ) -> AP_BEANIE:
+        for key, value in update_dict.items():
+            setattr(access_token, key, value)
+        await access_token.save()
+        return access_token
+
+    async def delete(self, access_token: AP_BEANIE) -> None:
+        await access_token.delete()

--- a/app/websocket_manager.py
+++ b/app/websocket_manager.py
@@ -1,0 +1,20 @@
+from fastapi import WebSocket
+
+
+class WebSocketManager:
+    def __init__(self):
+        self.active_connections: list[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket):
+        await websocket.accept()
+        self.active_connections.append(websocket)
+
+    def disconnect(self, websocket: WebSocket):
+        self.active_connections.remove(websocket)
+
+    async def send_personal_message(self, message: str, websocket: WebSocket):
+        await websocket.send_text(message)
+
+    async def broadcast(self, message: str):
+        for connection in self.active_connections:
+            await connection.send_text(message)

--- a/tests/test_3_groups.py
+++ b/tests/test_3_groups.py
@@ -14,6 +14,7 @@ from app.models.documents import Account, ResourceID
 # from app.exceptions.group import GroupNotFound
 from . import test_1_accounts
 from .test_2_workspaces import create_random_user, TestWorkspace
+from app.utils import permissions as Permissions
 
 # import pytest
 # from faker import Faker
@@ -50,10 +51,10 @@ class TestGroup(BaseModel):
 
 
 global accounts, workspace, groups
-accounts = [create_random_user() for _ in range(4)]
+accounts = [create_random_user() for _ in range(20)]
 workspace = TestWorkspace(name="Class CSE" + fake.aba(), description=fake.sentence())
 groups = [TestGroup(name="Teachers", description="Teachers of the course"),
-          TestGroup(name="Students", description="Students of the course")]
+          TestGroup(name="Group 02", description="Temp Description")]
 
 
 # Create a workspace and add users to it
@@ -78,7 +79,8 @@ async def test_prepare_workspace(client_test: AsyncClient):
 
     colored_dbg.test_info("Adding members to workspace")
     members = []  # List of member ids to add to the workspace
-    for account in accounts[1:]:  # Skip the first account since it is the creator of the workspace
+    students = accounts[1:10]
+    for account in students:  # Skip the first account since it is the creator of the workspace
         account = await test_1_accounts.test_register(client_test, account)  # test_register returns the new account id
         members.append(account.id)
         colored_dbg.test_info("Account {} + {} ({}) has registered".format(
@@ -108,7 +110,7 @@ async def test_create_group(client_test: AsyncClient):
     assert response.status_code == status.HTTP_200_OK
     response = response.json()
     assert response["groups"] == []
-    colored_dbg.test_success("Group has no groups")
+    colored_dbg.test_success("The workspace has no groups")
 
     # Create the groups
     for group in groups:
@@ -119,8 +121,7 @@ async def test_create_group(client_test: AsyncClient):
         response = response.json()
         assert response["name"] == group.name
         group.id = response["id"]  # Set the group id
-
-    colored_dbg.test_success("Created group {} with id {}".format(group.name, group.id))
+        colored_dbg.test_success("Created group {} with id {}".format(group.name, group.id))
 
 
 async def test_create_group_duplicate_name(client_test: AsyncClient):
@@ -150,7 +151,6 @@ async def test_get_groups(client_test: AsyncClient):
 
     # Get the first group(should be the only group)
     assert len(response["groups"]) == 2
-    print(response["groups"])
     for ws in response["groups"]:
         if ws["id"] == groups[0].id:
             assert groups[0].name == ws["name"]
@@ -205,239 +205,241 @@ async def test_get_group_info(client_test: AsyncClient):
     colored_dbg.test_success(f"Group \"{group.name}\" has one member: {active_user.email}")
 
 
-# async def test_update_group_info(client_test: AsyncClient):
-#     print("\n")
-#     colored_dbg.test_info("Update group info [PATCH /groups/{group.id}]")
-#     group = groups[1]
-#     active_user = accounts[0]
+async def test_update_group_info(client_test: AsyncClient):
+    print("\n")
+    colored_dbg.test_info("Update group info [PATCH /groups/{group.id}]")
+    group = groups[1]
+    active_user = accounts[0]
 
-#     # Update the group info
-#     group.name = "Updated Name"
-#     group.description = "Updated Description"
-#     response = await client_test.patch(f"/groups/{group.id}",
-#                                        json={"name": group.name, "description": group.description},
-#                                        headers={"Authorization": f"Bearer {active_user.token}"})
-#     assert response.status_code == status.HTTP_200_OK
-#     response = response.json()
-#     assert response["name"] == group.name
-#     assert response["description"] == group.description
-#     colored_dbg.test_success(f"Group {group.name} has updated name and description")
-
-
-# async def test_update_group_info_duplicate_name(client_test: AsyncClient):
-#     print("\n")
-#     colored_dbg.test_info("Update group info with duplicate name [PATCH /groups/{group.id}]")
-#     group = groups[1]
-#     active_user = accounts[0]
-
-#     # Update the group info
-#     response = await client_test.patch(f"/groups/{group.id}",
-#                                        json={"name": groups[0].name, "description": groups[0].description},
-#                                        headers={"Authorization": f"Bearer {active_user.token}"})
-#     assert response.status_code == status.HTTP_400_BAD_REQUEST
-#     colored_dbg.test_success(f"Group {group.name} cannot be updated with duplicate name")
+    # Update the group info
+    group.name = "Students"
+    group.description = "Students of the course"
+    response = await client_test.patch(f"/groups/{group.id}",
+                                       json={"name": group.name, "description": group.description},
+                                       headers={"Authorization": f"Bearer {active_user.token}"})
+    assert response.status_code == status.HTTP_200_OK
+    response = response.json()
+    assert response["name"] == group.name
+    assert response["description"] == group.description
+    colored_dbg.test_success(f"Group {group.name} has updated name and description")
 
 
-# async def test_add_members_to_group(client_test: AsyncClient):
-#     print("\n")
-#     colored_dbg.test_info("Add members to group [POST /groups/{group.id}/members]")
-#     group = groups[0]
-#     active_user = accounts[0]
+async def test_update_group_info_duplicate_name(client_test: AsyncClient):
+    print("\n")
+    colored_dbg.test_info("Update group info with duplicate name [PATCH /groups/{group.id}]")
+    group = groups[1]
+    active_user = accounts[0]
 
-#     members = []  # List of member ids to add to the group
-#     for account in accounts[1:]:  # Skip the first account since it is the creator of the group
-#         account = await test_1_accounts.test_register(client_test, account)  # test_register returns the new account id
-#         members.append(account.id)
-#         colored_dbg.test_info("Account {} + {} ({}) has registered".format(
-#             account.first_name, account.last_name, account.email))
-
-#     # Post the members to the group
-#     response = await client_test.post(f"/groups/{group.id}/members", json={"accounts": members},
-#                                       headers={"Authorization": f"Bearer {active_user.token}"})
-#     assert response.status_code == status.HTTP_200_OK
-#     response = response.json()
-#     for i in response["members"]:
-#         assert i["id"] in members
-#         members.remove(i["id"])
-#     assert members == []
-
-#     colored_dbg.test_success("All members have been successfully added to the group")
+    # Update the group info
+    response = await client_test.patch(f"/groups/{group.id}",
+                                       json={"name": groups[0].name, "description": groups[0].description},
+                                       headers={"Authorization": f"Bearer {active_user.token}"})
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    colored_dbg.test_success(f"Group {group.name} cannot be updated with duplicate name")
 
 
-# async def test_get_group_members(client_test: AsyncClient):
-#     print("\n")
-#     colored_dbg.test_info("Getting members of group [GET /groups/{group.id}/members]]")
-#     group = groups[0]
-#     active_user = accounts[0]
+async def test_add_members_to_group(client_test: AsyncClient):
+    print("\n")
+    colored_dbg.test_info("Add members to group [POST /groups/{group.id}/members]")
+    group = groups[0]
+    active_user = accounts[0]
 
-#     # Check that all users were added to the group as members
-#     response = await client_test.get(f"/groups/{group.id}/members",
-#                                      headers={"Authorization": f"Bearer {active_user.token}"})
-#     assert response.status_code == status.HTTP_200_OK
-#     response = response.json()
-#     assert len(response["members"]) == len(accounts)
-#     for acc in accounts:
-#         assert acc.dict(include={"id", "email", "first_name", "last_name"}) in response["members"]
+    members = []  # List of member ids to add to the group
+    students = accounts[1:10]
+    for account in students:  # Skip the first account since it is the creator of the group
+        members.append(account.id)
 
-#     colored_dbg.test_success("The group returned the correct list of members")
+    # Post the members to the group
+    response = await client_test.post(f"/groups/{group.id}/members", json={"accounts": members},
+                                      headers={"Authorization": f"Bearer {active_user.token}"})
+    assert response.status_code == status.HTTP_200_OK
+    response = response.json()
+    for i in response["members"]:
+        assert i["id"] in members
+        members.remove(i["id"])
+    assert members == []
 
-
-# async def test_get_permissions(client_test: AsyncClient):
-#     print("\n")
-#     colored_dbg.test_info("Getting list of member permissions in group [GET /groups/{group.id}/policy]")
-#     group = groups[0]
-#     active_user = accounts[0]
-
-#     # Check permission of the user who created the group
-#     response = await client_test.get(f"/groups/{group.id}/policy",
-#                                      headers={"Authorization": f"Bearer {active_user.token}"})
-#     assert response.status_code == status.HTTP_200_OK
-#     response = response.json()
-#     # Creator of the group should have all permissions
-#     assert response["permissions"] == Permissions.WORKSPACE_ALL_PERMISSIONS.name.split("|")  # type: ignore
-
-#     # Check permission of the rest of the members
-#     for i in range(1, len(accounts)):
-#         response = await client_test.get(f"/groups/{group.id}/policy",
-#                                          params={"account_id": accounts[i].id},  # type: ignore
-#                                          headers={"Authorization": f"Bearer {active_user.token}"})
-#         response = response.json()
-#         assert response["permissions"] == Permissions.WORKSPACE_BASIC_PERMISSIONS.name.split("|")  # type: ignore
-#     colored_dbg.test_success("All members have the correct permissions")
+    colored_dbg.test_success("All members have been successfully added to the group")
 
 
-# async def test_get_all_policies(client_test: AsyncClient):
-#     print("\n")
-#     colored_dbg.test_info("Getting all policies [GET /groups/{group.id}/policies]")
-#     group = groups[0]
-#     active_user = accounts[0]
+async def test_get_group_members(client_test: AsyncClient):
+    print("\n")
+    colored_dbg.test_info("Getting members of group [GET /groups/{group.id}/members]]")
+    group = groups[0]
+    active_user = accounts[0]
 
-#     # Check permission of the user who created the group
-#     response = await client_test.get(f"/groups/{group.id}/policies",
-#                                      headers={"Authorization": f"Bearer {active_user.token}"})
-#     assert response.status_code == status.HTTP_200_OK
-#     response = response.json()
-#     assert len(response["policies"]) == len(accounts)
-#     temp_acc_list = [acc.dict(include={"id", "email", "first_name", "last_name"}) for acc in accounts]
-#     for policy in response["policies"]:
-#         assert policy["policy_holder"] in temp_acc_list
-#         if policy["policy_holder"]["id"] == accounts[0].id:
-#             assert policy["permissions"] == Permissions.WORKSPACE_ALL_PERMISSIONS.name.split("|")
-#         else:
-#             assert policy["permissions"] == Permissions.WORKSPACE_BASIC_PERMISSIONS.name.split("|")
-#     colored_dbg.test_success("The group returned the correct list of policies")
+    # Check that all users were added to the group as members
+    response = await client_test.get(f"/groups/{group.id}/members",
+                                     headers={"Authorization": f"Bearer {active_user.token}"})
+    assert response.status_code == status.HTTP_200_OK
+    response = response.json()
+    assert len(response["members"]) == 10  # 10 accounts were added to the group
+    for acc in accounts[:10]:
+        assert acc.dict(include={"id", "email", "first_name", "last_name"}) in response["members"]
+
+    colored_dbg.test_success("The group returned the correct list of members")
 
 
-# async def test_permissions(client_test: AsyncClient):
-#     print("\n")
-#     colored_dbg.test_info("Actions and permissions")
-#     group = groups[0]
-#     active_user = accounts[1]
-#     await test_1_accounts.test_login(client_test, active_user)  # Login the active_user
+async def test_get_policy(client_test: AsyncClient):
+    print("\n")
+    colored_dbg.test_info("Getting list of member permissions in group [GET /groups/{group.id}/policy]")
+    group = groups[0]
+    active_user = accounts[0]
 
-#     # Try to get group info
-#     headers = {"Authorization": f"Bearer {active_user.token}"}
-#     res = await client_test.get(f"/groups/{group.id}", headers=headers)
-#     assert res.status_code == status.HTTP_200_OK
-#     res = res.json()
-#     assert res["name"] == group.name
-#     assert res["description"] == group.description
-#     colored_dbg.test_success("User #1 can get group info")
+    # Check permission of the user who created the group
+    response = await client_test.get(f"/groups/{group.id}/policy",
+                                     headers={"Authorization": f"Bearer {active_user.token}"})
+    assert response.status_code == status.HTTP_200_OK
+    response = response.json()
+    # Creator of the group should have all permissions
+    assert response["permissions"] == Permissions.GROUP_ALL_PERMISSIONS.name.split("|")  # type: ignore
 
-#     # Try to update group info
-#     res = await client_test.patch(f"/groups/{group.id}",
-#                                   json={"name": "New name", "description": "New description"},
-#                                   headers=headers)
-#     assert res.status_code == status.HTTP_403_FORBIDDEN
-
-#     # Try to delete group
-#     res = await client_test.delete(f"/groups/{group.id}", headers=headers)
-#     assert res.status_code == status.HTTP_403_FORBIDDEN
-
-#     # Try to get group members
-#     res = await client_test.get(f"/groups/{group.id}/members", headers=headers)
-#     assert res.status_code == status.HTTP_403_FORBIDDEN
-
-#     # Try to add members to group
-#     res = await client_test.post(f"/groups/{group.id}/members",
-#                                  json={"accounts": [accounts[2].id]},
-#                                  headers=headers)
-#     assert res.status_code == status.HTTP_403_FORBIDDEN
-
-#     # Try to get group list
-#     res = await client_test.get(f"/groups/{group.id}/groups", headers=headers)
-#     assert res.status_code == status.HTTP_403_FORBIDDEN
-
-#     # Try to create group
-#     res = await client_test.post(f"/groups/{group.id}/groups",
-#                                  json={"name": "New group", "description": "New description"},
-#                                  headers=headers)
-#     assert res.status_code == status.HTTP_403_FORBIDDEN
-
-#     # Try to delete members from group
-#     res = await client_test.delete(f"/groups/{group.id}/members/{accounts[2].id}",
-#                                    headers=headers)
-#     assert res.status_code == status.HTTP_403_FORBIDDEN
-
-#     # Try to get group permissions
-#     res = await client_test.get(f"/groups/{group.id}/policy", headers=headers)
-#     assert res.status_code == status.HTTP_403_FORBIDDEN
-
-#     # Try to set group permissions
-#     res = await client_test.put(f"/groups/{group.id}/policy",
-#                                 json={"permissions": Permissions.WORKSPACE_BASIC_PERMISSIONS.name.split("|")},
-#                                 headers=headers)
-#     assert res.status_code == status.HTTP_403_FORBIDDEN
-
-#     # TODO: Check if any actions were missed
-
-#     colored_dbg.test_success("User #1 can't do any actions without permissions")
+    # Check permission of the rest of the members
+    students = accounts[1:10]
+    for account in students:
+        response = await client_test.get(f"/groups/{group.id}/policy",
+                                         params={"account_id": account.id},  # type: ignore
+                                         headers={"Authorization": f"Bearer {active_user.token}"})
+        response = response.json()
+        assert response["permissions"] == Permissions.GROUP_BASIC_PERMISSIONS.name.split("|")  # type: ignore
+    colored_dbg.test_success("All members have the correct permissions")
 
 
-# async def test_set_permissions(client_test: AsyncClient):
-#     print("\n")
-#     colored_dbg.test_info("Setting permissions of group members [PUT /groups/{group.id}/policy]")
-#     active_user = accounts[0]
-#     group = groups[0]
+async def test_get_all_policies(client_test: AsyncClient):
+    print("\n")
+    colored_dbg.test_info("Getting all policies [GET /groups/{group.id}/policies]")
+    group = groups[0]
+    active_user = accounts[0]
 
-#     # Update policy of another member 
-#     response = await client_test.put(f"/groups/{group.id}/policy?",
-#                                      json={"account_id": accounts[1].id,
-#                                            "permissions": Permissions.WORKSPACE_ALL_PERMISSIONS.name.split("|")},
-#                                      headers={"Authorization": f"Bearer {active_user.token}"})
-#     assert response.status_code == status.HTTP_200_OK
-#     response = response.json()
-#     assert response["permissions"] == Permissions.WORKSPACE_ALL_PERMISSIONS.name.split("|")
-
-#     # Check permissions
-#     response = await client_test.get(f"/groups/{group.id}/policy?account_id={accounts[1].id}",
-#                                      headers={"Authorization": f"Bearer {active_user.token}"})
-#     assert response.status_code == status.HTTP_200_OK
-#     response = response.json()
-#     assert response["permissions"] == Permissions.WORKSPACE_ALL_PERMISSIONS.name.split("|")
-
-#     # Now the member should be able to get their policy information
-#     response = await client_test.get(f"/groups/{group.id}/policy",
-#                                      headers={"Authorization": f"Bearer {accounts[1].token}"})
-#     assert response.status_code == status.HTTP_200_OK
-#     response = response.json()
-#     assert response["permissions"] == Permissions.WORKSPACE_ALL_PERMISSIONS.name.split("|")
-
-#     colored_dbg.test_success("All members have the correct permissions")
+    # Check permission of the user who created the group
+    response = await client_test.get(f"/groups/{group.id}/policies",
+                                     headers={"Authorization": f"Bearer {active_user.token}"})
+    assert response.status_code == status.HTTP_200_OK
+    response = response.json()
+    assert len(response["policies"]) == 10  # 10 accounts were added to the group
+    temp_acc_list = [acc.dict(include={"id", "email", "first_name", "last_name"}) for acc in accounts]
+    for policy in response["policies"]:
+        assert policy["policy_holder"] in temp_acc_list
+        if policy["policy_holder"]["id"] == accounts[0].id:
+            assert policy["permissions"] == Permissions.GROUP_ALL_PERMISSIONS.name.split("|")
+        else:
+            assert policy["permissions"] == Permissions.GROUP_BASIC_PERMISSIONS.name.split("|")
+    colored_dbg.test_success("The group returned the correct list of policies")
 
 
-# # Attempt to remove a member from non existing group
-# async def test_delete_non_existing_group(client_test: AsyncClient):
-#     print("\n")
-#     colored_dbg.test_info("Testing group deletion from non existing group")
-#     active_user = accounts[1]
+async def test_permissions(client_test: AsyncClient):
+    print("\n")
+    colored_dbg.test_info("Actions and permissions")
+    group = groups[0]
+    active_user = accounts[1]
+    await test_1_accounts.test_login(client_test, active_user)  # Login the active_user
 
-#     random_group_id = ResourceID()
+    # Try to get group info
+    headers = {"Authorization": f"Bearer {active_user.token}"}
+    res = await client_test.get(f"/groups/{group.id}", headers=headers)
+    assert res.status_code == status.HTTP_200_OK
+    res = res.json()
+    assert res["name"] == group.name
+    assert res["description"] == group.description
+    colored_dbg.test_success("User #1 can get group info")
 
-#     response = await client_test.delete(f"/groups/{random_group_id}",
-#                                         headers={"Authorization": f"Bearer {active_user.token}"})
+    # Try to update group info
+    res = await client_test.patch(f"/groups/{group.id}",
+                                  json={"name": "New name", "description": "New description"},
+                                  headers=headers)
+    assert res.status_code == status.HTTP_403_FORBIDDEN
 
-#     assert response.status_code == status.HTTP_404_NOT_FOUND
+    # Try to delete group
+    res = await client_test.delete(f"/groups/{group.id}", headers=headers)
+    assert res.status_code == status.HTTP_403_FORBIDDEN
+
+    # Try to get group members
+    res = await client_test.get(f"/groups/{group.id}/members", headers=headers)
+    assert res.status_code == status.HTTP_403_FORBIDDEN
+
+    # Try to add members to group
+    res = await client_test.post(f"/groups/{group.id}/members",
+                                 json={"accounts": [accounts[2].id]},
+                                 headers=headers)
+    assert res.status_code == status.HTTP_403_FORBIDDEN
+
+    # # Try to get group list
+    # res = await client_test.get(f"/groups/{group.id}/groups", headers=headers)
+    # assert res.status_code == status.HTTP_403_FORBIDDEN
+
+    # # Try to create group
+    # res = await client_test.post(f"/groups/{group.id}/groups",
+    #                              json={"name": "New group", "description": "New description"},
+    #                              headers=headers)
+    # assert res.status_code == status.HTTP_403_FORBIDDEN
+
+    # Try to delete members from group
+    res = await client_test.delete(f"/groups/{group.id}/members/{accounts[2].id}",
+                                   headers=headers)
+    assert res.status_code == status.HTTP_403_FORBIDDEN
+
+    # Try to get group permissions
+    res = await client_test.get(f"/groups/{group.id}/policy", headers=headers)
+    assert res.status_code == status.HTTP_403_FORBIDDEN
+
+    # Try to set group permissions
+    res = await client_test.put(f"/groups/{group.id}/policy",
+                                json={"permissions": Permissions.GROUP_BASIC_PERMISSIONS.name.split("|")},
+                                headers=headers)
+    assert res.status_code == status.HTTP_403_FORBIDDEN
+
+    # TODO: Check if any actions were missed
+
+    colored_dbg.test_success("User #1 can't do any actions without permissions")
+
+
+async def test_set_permissions(client_test: AsyncClient):
+    print("\n")
+    colored_dbg.test_info("Setting permissions of group members [PUT /groups/{group.id}/policy]")
+    active_user = accounts[0]
+    group = groups[0]
+
+    # Update policy of another member
+    response = await client_test.put(f"/groups/{group.id}/policy?",
+                                     json={"account_id": accounts[1].id,
+                                           "permissions": Permissions.GROUP_ALL_PERMISSIONS.name.split("|")},
+                                     headers={"Authorization": f"Bearer {active_user.token}"})
+    assert response.status_code == status.HTTP_200_OK
+    response = response.json()
+    assert response["permissions"] == Permissions.GROUP_ALL_PERMISSIONS.name.split("|")
+
+    # Check permissions
+    response = await client_test.get(f"/groups/{group.id}/policy?account_id={accounts[1].id}",
+                                     headers={"Authorization": f"Bearer {active_user.token}"})
+    assert response.status_code == status.HTTP_200_OK
+    response = response.json()
+    assert response["permissions"] == Permissions.GROUP_ALL_PERMISSIONS.name.split("|")
+
+    # Now the member should be able to get their policy information
+    await test_1_accounts.test_login(client_test, accounts[1])  # Login the active_user
+    colored_dbg.test_success("Signed in under {} {} ({})".format(
+        accounts[1].first_name, accounts[1].last_name, accounts[1].email))
+    response = await client_test.get(f"/groups/{group.id}/policy",
+                                     headers={"Authorization": f"Bearer {accounts[1].token}"})
+    assert response.status_code == status.HTTP_200_OK
+    response = response.json()
+    assert response["permissions"] == Permissions.GROUP_ALL_PERMISSIONS.name.split("|")
+
+    colored_dbg.test_success("All members have the correct permissions")
+
+
+# Attempt to remove a member from non existing group
+async def test_delete_non_existing_group(client_test: AsyncClient):
+    print("\n")
+    colored_dbg.test_info("Testing group deletion from non existing group")
+    active_user = accounts[0]
+
+    random_group_id = ResourceID()
+
+    response = await client_test.delete(f"/groups/{random_group_id}",
+                                        headers={"Authorization": f"Bearer {active_user.token}"})
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 # Delete the groups
@@ -449,16 +451,17 @@ async def test_delete_group(client_test: AsyncClient):
 
     for group in groups:
         # Get the group
+        colored_dbg.test_info("Searching for group")
         response = await client_test.get(f"/groups/{group.id}", headers=headers)
         assert response.status_code == status.HTTP_200_OK
         response = response.json()
         assert response["name"] == group.name
-        colored_dbg.test_info(f'Group "{group.name}" found')
+        colored_dbg.test_success(f'Group "{group.name}" found')
 
         # Delete the group
+        colored_dbg.test_info(f'Deleting group "{group.name}"')
         response = await client_test.delete(f"/groups/{group.id}", headers=headers)
         assert response.status_code == status.HTTP_204_NO_CONTENT
-        colored_dbg.test_info(f'Deleting group "{group.name}"')
 
         # Test to get the group
         response = await client_test.get(f"/groups/{group.id}", headers=headers)


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
The provided authentication from [fastapi-users](https://github.com/fastapi-users/fastapi-users) library was lacking functionality for refreshing tokens which is useful for testing purposes and should improve overall user experience since there won't be a need to re-login after the Access token expires. For example, with this strategy Postman client can refresh token automatically. 

The new authentication strategy involves few classes and stores tokens in Access Token collection in MongoDB.
The Access Token expires in 1 hour after generating. The Refresh token that is issued along access token can be used to get a new pair of both. For security purposes the refresh token can only be used once and use of expired token will deactivate all of them requiring user to login with credentials.

## ✅ Updates
- [x] Custom Authentication strategy
- [x] Database for tokens
- [x] Refresh tokens functionality
- [x] Expiration time for access tokens
- [x] Route to refresh access token
- [ ] Unit Testing
- [ ] Documentation
- [ ] Cookies Support
