### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,22 @@ FROM python:3.11-alpine
 
 WORKDIR /unipoll-api
 
-COPY ./requirements.txt /unipoll-api/requirements.txt
+COPY ./pyproject.toml /unipoll-api/pyproject.toml
 
-RUN pip install --no-cache-dir -r /unipoll-api/requirements.txt
+COPY ./src/ /unipoll-api/src/
 
-COPY ./src/ /unipoll-api/
+RUN pip install build
 
-CMD ["uvicorn", "unipoll_api.app:app"]
+RUN python -m build
+
+FROM python:3.11-alpine
+
+WORKDIR /unipoll-api
+
+COPY --from=0 /unipoll-api/dist/*.tar.gz .
+
+RUN tar -xf unipoll-api-*.tar.gz --strip-components=1
+
+RUN pip install .
+
+ENTRYPOINT [ "unipoll-api" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.11-alpine
 
 WORKDIR /unipoll-api
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ max-line-length = 120
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
+testpaths = ["tests"]
 addopts = "--cov --cov-report lcov"
 asyncio_mode="auto"
 filterwarnings = [

--- a/src/unipoll_api/mongo_db.py
+++ b/src/unipoll_api/mongo_db.py
@@ -5,10 +5,11 @@ from unipoll_api.config import get_settings
 settings = get_settings()
 
 client = motor.motor_asyncio.AsyncIOMotorClient(
-    settings.mongodb_url, uuidRepresentation="standard"
+    host=settings.mongodb_url,
+    uuidRepresentation="standard",
 )
-mainDB = client.app
 
+mainDB = client["unipoll-api"]
 
 documentModels = [
     Documents.AccessToken,


### PR DESCRIPTION
- Renamed Mongo Database from `app` to `unipoll-api`
- Changed docker base image from `python:3.11` to `python:3.11-alpine`, which reduces the image size 
- Changed Dockerfile to use unipoll-api entry point